### PR TITLE
Tweak cron time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,10 @@ workflows:
       - test_rubocop
     triggers:
       - schedule:
-          cron: "30 1 * * *"
+          # Run the task while I'm sleeping.
+          # JST: 4:30AM
+          # UTC: 19:30
+          cron: "30 19 * * *" 
           filters:
             branches:
               only:


### PR DESCRIPTION
Current time (UTC 1:30AM, JST 10:30AM) is morning in Japan.
I'd like to execute the job while I'm sleeping because it will not conflict with other CircleCI jobs.