### PR TITLE
Fix usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ $ bundle exec rake install
 $ cd /path/to/pocke/rubocop-regression-test
 
 # Run on specified repo, all configuration conbinations
-$ ruby main.rb owner/repo
+$ ruby main.rb check owner/repo
 ```


### PR DESCRIPTION
`ruby main.rb owner/repo` command just show the Usage.

```
$ ruby main.rb tric/trick2015
Usage:
  ruby main.rb check OWNER/REPO         # Run the test
  ruby main.rb check GIT_CLONEABLE_PATH # Run the test
  ruby main.rb config NUMBER            # Generate configuration
  ruby main.rb help                     # Display this message
```

So this patch will update README with expected command to check rubocop.